### PR TITLE
feat: add GitHub workflows and tests from starting-point

### DIFF
--- a/.github/docs/SETUP.md
+++ b/.github/docs/SETUP.md
@@ -1,0 +1,51 @@
+# Repository Setup
+
+When creating a new repository from this template, follow these configuration steps:
+
+## 1. Configure Workflow Permissions
+
+Go to Settings → Actions → General and configure:
+
+### Workflow Permissions
+
+- Select "Read and write permissions"
+- Check "Allow GitHub Actions to create and approve pull requests"
+- Click "Save"
+
+### Fork Pull Request Workflows
+
+- Choose whether to run workflows from fork pull requests
+- Note: This gives fork maintainers ability to use tokens with read permissions
+- Click "Save"
+
+### Access
+
+- Select "Not accessible" if you want to restrict workflow access
+- Or "Accessible from repositories in your organization" for org-wide access
+- Click "Save"
+
+## 2. Configure Branch Protection
+
+Go to Settings → Branches and add a rule for the `main` branch:
+
+- Require pull request reviews
+- Require status checks to pass
+- Require signed commits
+- Include administrators
+
+## 3. Configure GPG Signing
+
+The repository uses GitHub's native commit verification. All commits, including those from GitHub Actions, must be signed.
+
+1. For manual commits:
+   - See [CONTRIBUTING.md](../../CONTRIBUTING.md) for detailed commit signing instructions
+
+2. For automated commits:
+   - GitHub Actions bot is configured to sign commits automatically
+   - Uses repository secrets for GPG key and passphrase
+   - No additional setup needed for contributors
+
+For more details on commit signing and workflow testing, see:
+
+- [Contributing Guidelines](../../CONTRIBUTING.md)
+- [Testing Documentation](./TESTING.md)

--- a/.github/docs/TESTING.md
+++ b/.github/docs/TESTING.md
@@ -1,0 +1,40 @@
+# Testing and Development Setup
+
+## Testing GitHub Actions Locally
+
+We recommend using [act](https://github.com/nektos/act) to test GitHub Actions workflows locally before pushing changes if you are developing on a Mac.
+
+The application does not have to be running in Docker to test the workflows, but Docker Desktop must be running for the act tests to run and spin up the necessary containers.
+
+### Prerequisites for macOS
+
+- Homebrew
+- Docker Desktop (must be running)
+
+```sh
+# Install act using Homebrew
+brew install act
+
+# Verify installation
+act --version # Should show 0.2.76 or higher
+```
+
+### Running Tests
+
+The following test scripts are available from the root of the repository:
+
+1. `npm test` - Run all tests and GitHub workflows
+2. `npm run test:workflows` - Only test GitHub workflows
+
+### What the Tests Do
+
+The test scripts validate the GitHub Actions workflows in this repository:
+
+- **PR Title Check**: Validates PR titles against conventional commit format
+- **Version Bump**: Tests the automatic version bumping workflow
+- **GHCR Cleanup**: Tests the GitHub Container Registry cleanup workflow
+
+### Expected Test Results
+
+- Some tests may show git authentication errors when run locally (this is expected)
+- Full workflow functionality can only be tested in the GitHub Actions environment

--- a/.github/docs/act-testing.md
+++ b/.github/docs/act-testing.md
@@ -1,0 +1,46 @@
+# ACT Testing and Container Management
+
+This document explains how the ACT testing framework is used in the starting-point project and how we manage Docker containers created during testing.
+
+## Overview
+
+We use [act](https://github.com/nektos/act) to test GitHub Actions workflows locally. This allows us to verify that our workflows function correctly before pushing changes to GitHub.
+
+## Container Cleanup
+
+When running tests with ACT, Docker containers are created to simulate the GitHub Actions environment. Sometimes these containers may not be properly cleaned up, especially if a test is interrupted or fails.
+
+### Automatic Cleanup
+
+We've implemented automatic container cleanup in our testing scripts:
+
+1. Before running any tests, orphaned containers from previous test runs are removed
+2. After each individual test, containers from that test are cleaned up
+3. At the end of the test suite, a final cleanup is performed to ensure no containers are left behind
+
+## Implementation Details
+
+The cleanup functionality is implemented in two places:
+
+1. `.github/test-workflows.sh` - Contains the `cleanup_act_containers()` function that is called before and after each test
+
+### Cleanup Function
+
+The cleanup function works by:
+
+1. Finding all Docker containers with "act" in their name
+2. Removing these containers forcefully
+
+```bash
+cleanup_act_containers() {
+  echo "🧹 Cleaning up act containers..."
+  orphaned_containers=$(docker ps -a | grep act | awk '{print $1}')
+  if [ -n "$orphaned_containers" ]; then
+    echo "Found orphaned containers: $orphaned_containers"
+    docker rm -f $orphaned_containers
+    echo "✅ Containers removed successfully"
+  else
+    echo "No orphaned containers found"
+  fi
+}
+```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Description
+
+<!-- Describe your changes here -->
+
+## Type of Change
+
+<!-- Add one of these version tags: -->
+version: feat     # New feature (minor version bump)
+version: feat!    # Breaking change (major version bump)
+version: fix      # Bug fix (patch version bump)
+version: docs     # Documentation changes
+version: style    # Code style/formatting
+version: refactor # Code refactoring
+version: perf     # Performance improvements
+version: test     # Adding/updating tests
+version: build    # Dependencies/build changes
+version: ci       # CI/CD changes
+version: chore    # General maintenance
+version: revert   # Reverting changes
+
+## Testing
+
+- [ ] I have tested these changes locally using `act`
+- [ ] All existing tests pass
+- [ ] My commits are signed with GPG

--- a/.github/scripts/generate-gpg-key.sh
+++ b/.github/scripts/generate-gpg-key.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Configuration
+BOT_NAME="github-actions[bot]"
+BOT_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+KEY_COMMENT="GitHub Actions bot (TheRobBrennan)"
+
+# Pasphrase can be provided via the PASSPHRASE environment variable
+# or entered interactively when running this script.
+if [ -z "$PASSPHRASE" ]; then
+  echo "Enter passphrase for new GPG key:"
+  read -s PASSPHRASE
+  echo "Confirm passphrase:"
+  read -s PASSPHRASE_CONFIRM
+
+  if [ "$PASSPHRASE" != "$PASSPHRASE_CONFIRM" ]; then
+    echo "Error: Passphrases do not match"
+    exit 1
+  fi
+
+  if [ -z "$PASSPHRASE" ]; then
+    echo "Error: Passphrase cannot be empty"
+    exit 1
+  fi
+fi
+
+# if [ "$PASSPHRASE" != "$PASSPHRASE_CONFIRM" ]; then
+#     echo "Error: Passphrases do not match"
+#     exit 1
+# fi
+
+# if [ -z "$PASSPHRASE" ]; then
+#     echo "Error: Passphrase cannot be empty"
+#     exit 1
+# fi
+
+# Generate GPG key configuration file
+cat > gpg-key-config <<EOF
+%echo Generating GPG key for GitHub Actions
+Key-Type: RSA
+Key-Length: 4096
+Key-Usage: sign
+Subkey-Type: RSA
+Subkey-Length: 4096
+Subkey-Usage: encrypt
+Name-Real: $BOT_NAME
+Name-Comment: $KEY_COMMENT
+Name-Email: $BOT_EMAIL
+Expire-Date: 0
+Passphrase: $PASSPHRASE
+%commit
+%echo Done
+EOF
+
+# Generate key
+gpg --batch --generate-key gpg-key-config
+
+# Export public key
+KEY_ID=$(gpg --list-secret-keys --keyid-format LONG "$BOT_EMAIL" | grep sec | awk '{print $2}' | cut -d'/' -f2)
+echo -e "\nPublic Key:"
+gpg --armor --export $KEY_ID
+
+# Export private key (for GitHub secret)
+echo -e "\nPrivate Key (for GitHub secret):"
+gpg --armor --export-secret-key $KEY_ID
+
+# Cleanup
+rm gpg-key-config
+
+echo -e "\nKey generation complete!"
+echo "Key ID: $KEY_ID"
+echo "Email: $BOT_EMAIL"
+echo "Remember to store the passphrase securely - you'll need it for the GPG_PASSPHRASE secret in GitHub" 

--- a/.github/test-data/README.md
+++ b/.github/test-data/README.md
@@ -1,0 +1,12 @@
+# GitHub Actions Test Data
+
+This directory contains test data files used for local testing of GitHub Actions workflows using [act](https://github.com/nektos/act).
+
+## Directory Structure
+
+- `pr-events/` - Contains example Pull Request event payloads
+  - `major.json` - Example of a breaking change PR
+  - `minor.json` - Example of a feature addition PR
+  - `patch.json` - Example of a bug fix PR
+  - `invalid.json` - Example of an invalid PR format
+  - `merge.json` - Example of a PR merge event

--- a/.github/test-data/pr-events/breaking.json
+++ b/.github/test-data/pr-events/breaking.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "title": "feat!: redesign authentication system",
+        "body": "BREAKING CHANGE: Complete overhaul of auth system",
+        "number": 1,
+        "html_url": "https://github.com/TheRobBrennan/starting-point/pull/1"
+    },
+    "repository": {
+        "full_name": "TheRobBrennan/starting-point",
+        "html_url": "https://github.com/TheRobBrennan/starting-point"
+    }
+}

--- a/.github/test-data/pr-events/example.json
+++ b/.github/test-data/pr-events/example.json
@@ -1,0 +1,6 @@
+{
+    "pull_request": {
+        "title": "feat: add semantic PR checking",
+        "body": "Adding semantic versioning checks to PRs"
+    }
+}

--- a/.github/test-data/pr-events/invalid.json
+++ b/.github/test-data/pr-events/invalid.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "title": "adding some feature without proper format",
+        "body": "This PR title doesn't follow semantic versioning",
+        "number": 1,
+        "html_url": "https://github.com/TheRobBrennan/starting-point/pull/1"
+    },
+    "repository": {
+        "full_name": "TheRobBrennan/starting-point",
+        "html_url": "https://github.com/TheRobBrennan/starting-point"
+    }
+}

--- a/.github/test-data/pr-events/major.json
+++ b/.github/test-data/pr-events/major.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "title": "feat!: redesign authentication system",
+        "body": "BREAKING CHANGE: Complete overhaul of auth system",
+        "number": 1,
+        "html_url": "https://github.com/TheRobBrennan/starting-point/pull/1"
+    },
+    "repository": {
+        "full_name": "TheRobBrennan/starting-point",
+        "html_url": "https://github.com/TheRobBrennan/starting-point"
+    }
+}

--- a/.github/test-data/pr-events/merge-bot-signed.json
+++ b/.github/test-data/pr-events/merge-bot-signed.json
@@ -1,0 +1,12 @@
+{
+    "commits": [
+        {
+            "message": "Merge pull request #123 from TheRobBrennan/fix/bot-signing\n\nfix: configure GitHub Actions bot identity for signed commits\n\nFixes unverified commits from GitHub Actions bot"
+        }
+    ],
+    "pull_request": {
+        "title": "fix: configure GitHub Actions bot identity for signed commits",
+        "body": "Fixes unverified commits from GitHub Actions bot",
+        "number": 123
+    }
+}

--- a/.github/test-data/pr-events/merge.json
+++ b/.github/test-data/pr-events/merge.json
@@ -1,0 +1,12 @@
+{
+    "commits": [
+        {
+            "message": "Merge pull request #123 from TheRobBrennan:feature/new-feature\n\nfeat: add new feature\n\nAdds a new feature to the project"
+        }
+    ],
+    "pull_request": {
+        "title": "feat: add new feature",
+        "body": "Adds a new feature to the project",
+        "number": 123
+    }
+}

--- a/.github/test-data/pr-events/minor.json
+++ b/.github/test-data/pr-events/minor.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "title": "feat: add new feature",
+        "body": "Adding new feature to the project",
+        "number": 2,
+        "html_url": "https://github.com/TheRobBrennan/starting-point/pull/2"
+    },
+    "repository": {
+        "full_name": "TheRobBrennan/starting-point",
+        "html_url": "https://github.com/TheRobBrennan/starting-point"
+    }
+}

--- a/.github/test-data/pr-events/patch.json
+++ b/.github/test-data/pr-events/patch.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "title": "fix: correct bug in core functionality",
+        "body": "Fixed bug in core functionality",
+        "number": 3,
+        "html_url": "https://github.com/TheRobBrennan/starting-point/pull/3"
+    },
+    "repository": {
+        "full_name": "TheRobBrennan/starting-point",
+        "html_url": "https://github.com/TheRobBrennan/starting-point"
+    }
+}

--- a/.github/test-data/pr-events/workflow-dispatch.json
+++ b/.github/test-data/pr-events/workflow-dispatch.json
@@ -1,0 +1,8 @@
+{
+  "action": "workflow_dispatch",
+  "inputs": {
+    "dry_run": true,
+    "days_old": 7,
+    "keep_versions": 2
+  }
+}

--- a/.github/test-workflows.sh
+++ b/.github/test-workflows.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Function to clean up orphaned act containers
+cleanup_act_containers() {
+  echo "🧹 Cleaning up act containers..."
+  orphaned_containers=$(docker ps -a | grep act | awk '{print $1}')
+  if [ -n "$orphaned_containers" ]; then
+    echo "Found orphaned containers: $orphaned_containers"
+    docker rm -f $orphaned_containers
+    echo "✅ Containers removed successfully"
+  else
+    echo "No orphaned containers found"
+  fi
+  echo ""
+}
+
+# Clean up any existing act containers before starting tests
+cleanup_act_containers
+
+echo "🧪 Testing GitHub Actions workflows..."
+echo ""
+
+echo "📋 Testing PR Title Check workflow..."
+echo ""
+
+echo "1. Testing major version bump (breaking change)..."
+act pull_request -e .github/test-data/pr-events/major.json -W .github/workflows/pr-title-check.yml --container-architecture linux/amd64
+cleanup_act_containers
+echo ""
+
+echo "2. Testing minor version bump (new feature)..."
+act pull_request -e .github/test-data/pr-events/minor.json -W .github/workflows/pr-title-check.yml --container-architecture linux/amd64
+cleanup_act_containers
+echo ""
+
+echo "3. Testing patch version bump (fix)..."
+act pull_request -e .github/test-data/pr-events/patch.json -W .github/workflows/pr-title-check.yml --container-architecture linux/amd64
+cleanup_act_containers
+echo ""
+
+echo "4. Testing invalid PR format..."
+act pull_request -e .github/test-data/pr-events/invalid.json -W .github/workflows/pr-title-check.yml --container-architecture linux/amd64
+cleanup_act_containers
+echo ""
+
+echo "🔄 Testing Version Bump workflow..."
+echo ""
+echo "Note: The following tests will show authentication errors - this is expected behavior when testing locally"
+echo "These operations require the GitHub Actions environment and will work properly when running in GitHub"
+echo ""
+
+echo "Testing version bump functionality..."
+act push -e .github/test-data/pr-events/merge.json -W .github/workflows/version-bump.yml --container-architecture linux/amd64 -s GITHUB_TOKEN="test-token" -s GPG_PRIVATE_KEY="test-key" -s GPG_PASSPHRASE="test-passphrase"
+cleanup_act_containers
+echo ""
+
+# Add test for our new GPG signing functionality
+echo "Testing GPG signing with GitHub Actions bot..."
+echo "Note: GPG signing tests will fail locally - this is expected"
+act push -e .github/test-data/pr-events/merge-bot-signed.json -W .github/workflows/version-bump.yml --container-architecture linux/amd64 -s GITHUB_TOKEN="test-token" -s GPG_PRIVATE_KEY="test-key" -s GPG_PASSPHRASE="test-passphrase"
+cleanup_act_containers
+echo ""
+
+# Test GHCR Cleanup workflow
+echo "🧹 Testing GHCR Cleanup workflow..."
+echo ""
+echo "Testing GHCR Cleanup with dry run..."
+act workflow_dispatch -e .github/test-data/pr-events/workflow-dispatch.json -W .github/workflows/ghcr-cleanup.yml --container-architecture linux/amd64 -s GITHUB_TOKEN="test-token"
+cleanup_act_containers
+echo ""
+
+# Final cleanup to ensure no containers are left behind
+cleanup_act_containers

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,227 @@
+name: GHCR Cleanup
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'  # Weekly on Sunday at 2 AM UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (no deletions)'
+        type: boolean
+        default: true
+      days_old:
+        description: 'Delete versions older than X days'
+        type: number
+        default: 1
+      keep_versions:
+        description: 'Always keep this many recent versions'
+        type: number
+        default: 2
+
+jobs:
+  cleanup-ghcr:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      
+    steps:
+      - name: Clean GHCR Container Images
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          DRY_RUN: ${{ inputs.dry_run || 'true' }}
+          DAYS_OLD: ${{ inputs.days_old || 1 }}
+          KEEP_VERSIONS: ${{ inputs.keep_versions || 2 }}
+        run: |
+          echo "🧹 GHCR Container Image Cleanup"
+          echo "Repository: $ORG/$REPO"
+          echo "Settings: DRY_RUN=$DRY_RUN, DAYS_OLD=$DAYS_OLD days, KEEP_VERSIONS=$KEEP_VERSIONS"
+          echo "----------------------------------------"
+          
+          # Calculate cutoff date
+          CUTOFF_TIMESTAMP=$(date -d "${DAYS_OLD} days ago" --iso-8601)
+          echo "Cutoff date: $CUTOFF_TIMESTAMP"
+          echo ""
+          
+          # Dynamically discover container packages for this repository
+          echo "🔍 Discovering container packages for repository $ORG/$REPO..."
+          
+          # Test for known package patterns that could exist for this repository
+          CANDIDATE_PACKAGES=(
+            "$REPO"  # Same as repository name
+            "payloadcms"  # Common package name pattern
+            "$(echo $REPO | tr '[:upper:]' '[:lower:]')"  # Lowercase version
+            "$(echo $REPO | sed 's/-web-[0-9]*$//')"  # Remove version suffix if present
+          )
+          
+          # Remove duplicates and empty entries
+          UNIQUE_CANDIDATES=($(printf '%s\n' "${CANDIDATE_PACKAGES[@]}" | sort -u | grep -v '^$'))
+          
+          echo "  🔍 Testing candidate packages: ${UNIQUE_CANDIDATES[*]}"
+          
+          PACKAGES=()
+          for CANDIDATE in "${UNIQUE_CANDIDATES[@]}"; do
+            echo "  🔍 Testing package: $CANDIDATE"
+            
+            # Try org endpoint first
+            ORG_TEST=$(gh api "orgs/$ORG/packages/container/$CANDIDATE/versions" --paginate 2>/dev/null || echo "")
+            if [ -n "$ORG_TEST" ] && echo "$ORG_TEST" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+              echo "    ✅ Found $CANDIDATE via org endpoint"
+              PACKAGES+=("$CANDIDATE")
+              continue
+            fi
+            
+            # Try user endpoint if org failed
+            USER_TEST=$(gh api "user/packages/container/$CANDIDATE/versions" --paginate 2>/dev/null || echo "")
+            if [ -n "$USER_TEST" ] && echo "$USER_TEST" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+              echo "    ✅ Found $CANDIDATE via user endpoint"
+              PACKAGES+=("$CANDIDATE")
+              continue
+            fi
+            
+            echo "    ❌ Package $CANDIDATE not found"
+          done
+          
+          if [ ${#PACKAGES[@]} -eq 0 ]; then
+            echo "  ⚠️  No container packages found for this repository"
+            echo "🎯 Final Summary: No packages to process"
+            exit 0
+          fi
+          
+          echo "  📋 Found ${#PACKAGES[@]} package(s):"
+          for pkg in "${PACKAGES[@]}"; do
+            echo "    - $pkg"
+          done
+          echo ""
+          
+          TOTAL_DELETED=0
+          TOTAL_KEPT=0
+          
+          for PACKAGE in "${PACKAGES[@]}"; do
+            echo "📦 Processing package: $PACKAGE"
+            
+            # Get package versions - try org endpoint first, then user endpoint
+            echo "  🔍 Fetching package versions..."
+            VERSIONS_JSON=""
+            
+            # Try organization endpoint first
+            echo "  🔍 Trying org endpoint for $PACKAGE..."
+            ORG_RESPONSE=$(gh api "orgs/$ORG/packages/container/$PACKAGE/versions" --paginate 2>/dev/null || echo "")
+            if [ -n "$ORG_RESPONSE" ] && echo "$ORG_RESPONSE" | jq empty 2>/dev/null && [ "$ORG_RESPONSE" != "[]" ]; then
+              VERSIONS_JSON="$ORG_RESPONSE"
+              echo "  ✅ Found package via org endpoint"
+            fi
+            
+            # Try user endpoint if org failed
+            if [ -z "$VERSIONS_JSON" ]; then
+              echo "  🔍 Trying user endpoint for $PACKAGE..."
+              USER_RESPONSE=$(gh api "user/packages/container/$PACKAGE/versions" --paginate 2>/dev/null || echo "")
+              if [ -n "$USER_RESPONSE" ] && echo "$USER_RESPONSE" | jq empty 2>/dev/null && [ "$USER_RESPONSE" != "[]" ]; then
+                VERSIONS_JSON="$USER_RESPONSE"
+                echo "  ✅ Found package via user endpoint"
+              fi
+            fi
+            
+            # Check if we found any versions
+            if [ -z "$VERSIONS_JSON" ] || [ "$VERSIONS_JSON" = "[]" ]; then
+              echo "  ⚠️  Package '$PACKAGE' not found in org or user scope"
+              continue
+            fi
+            
+            # Count total versions
+            VERSION_COUNT=$(echo "$VERSIONS_JSON" | jq 'length' 2>/dev/null || echo "0")
+            echo "  💾 Found $VERSION_COUNT versions"
+            
+            if [ "$VERSION_COUNT" -eq 0 ]; then
+              echo "  ℹ️  No versions to process"
+              continue
+            fi
+            
+            # Sort versions by creation date (newest first) and process
+            echo "  🔍 Processing versions..."
+            echo "$VERSIONS_JSON" | jq -r '.[] | [.id, .created_at, (.metadata.container.tags // [] | if length > 0 then join(",") else "<untagged>" end), .updated_at] | @csv' 2>/dev/null | \
+            sort -t, -k2 -r | \
+            {
+              KEPT_COUNT=0
+              PACKAGE_DELETED=0
+              PROCESSED_COUNT=0
+              
+              while IFS=, read -r VERSION_ID CREATED_AT TAGS UPDATED_AT; do
+                # Remove CSV quotes
+                VERSION_ID=$(echo "$VERSION_ID" | tr -d '"')
+                CREATED_AT=$(echo "$CREATED_AT" | tr -d '"')
+                TAGS=$(echo "$TAGS" | tr -d '"')
+                UPDATED_AT=$(echo "$UPDATED_AT" | tr -d '"')
+                
+                PROCESSED_COUNT=$((PROCESSED_COUNT + 1))
+                
+                # Always keep the most recent versions regardless of age
+                if [ $KEPT_COUNT -lt $KEEP_VERSIONS ]; then
+                  echo "  ✅ Keeping version $VERSION_ID (tags: $TAGS) - protected (${KEPT_COUNT}/${KEEP_VERSIONS})"
+                  KEPT_COUNT=$((KEPT_COUNT + 1))
+                  continue
+                fi
+                
+                # Check if version is older than cutoff
+                CREATED_DATE=$(echo "$CREATED_AT" | cut -d'T' -f1)
+                CUTOFF_DATE=$(date -d "${DAYS_OLD} days ago" +%Y-%m-%d)
+                
+                if [[ "$CREATED_DATE" < "$CUTOFF_DATE" ]]; then
+                  echo "  🗑️  Candidate for deletion: $VERSION_ID (created: $CREATED_DATE, tags: $TAGS)"
+                  
+                  if [ "$DRY_RUN" = "false" ]; then
+                    echo "    🔥 Deleting version $VERSION_ID..."
+                    DELETE_SUCCESS=false
+                    
+                    # Try org endpoint first
+                    if gh api -X DELETE "orgs/$ORG/packages/container/$PACKAGE/versions/$VERSION_ID" >/dev/null 2>&1; then
+                      DELETE_SUCCESS=true
+                    elif gh api -X DELETE "user/packages/container/$PACKAGE/versions/$VERSION_ID" >/dev/null 2>&1; then
+                      DELETE_SUCCESS=true
+                    fi
+                    
+                    if [ "$DELETE_SUCCESS" = "true" ]; then
+                      echo "    ✅ Successfully deleted version $VERSION_ID"
+                      PACKAGE_DELETED=$((PACKAGE_DELETED + 1))
+                    else
+                      echo "    ❌ Failed to delete version $VERSION_ID"
+                    fi
+                  else
+                    echo "    💭 DRY RUN: Would delete version $VERSION_ID"
+                    PACKAGE_DELETED=$((PACKAGE_DELETED + 1))
+                  fi
+                else
+                  echo "  ✅ Keeping version $VERSION_ID (created: $CREATED_DATE) - within retention period"
+                  KEPT_COUNT=$((KEPT_COUNT + 1))
+                fi
+              done
+              
+              echo "  📊 Package summary: $PROCESSED_COUNT total, $KEPT_COUNT kept, $PACKAGE_DELETED $([ "$DRY_RUN" = "true" ] && echo "would be deleted" || echo "deleted")"
+              
+              # Update totals (using temp files since we're in a subshell)
+              echo $((TOTAL_DELETED + PACKAGE_DELETED)) > /tmp/total_deleted
+              echo $((TOTAL_KEPT + KEPT_COUNT)) > /tmp/total_kept
+            }
+            
+            # Read totals back from temp files
+            TOTAL_DELETED=$(cat /tmp/total_deleted 2>/dev/null || echo $TOTAL_DELETED)
+            TOTAL_KEPT=$(cat /tmp/total_kept 2>/dev/null || echo $TOTAL_KEPT)
+            
+            echo ""
+          done
+          
+          # Cleanup temp files
+          rm -f /tmp/total_deleted /tmp/total_kept
+          
+          echo "🎯 Final Summary:"
+          echo "  📊 Total versions processed: $((TOTAL_KEPT + TOTAL_DELETED))"
+          echo "  ✅ Total versions kept: $TOTAL_KEPT"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "  🔍 DRY RUN: Would delete $TOTAL_DELETED versions"
+            echo ""
+            echo "💡 To actually delete these versions, re-run with dry_run=false"
+          else
+            echo "  🗑️  Total versions deleted: $TOTAL_DELETED"
+          fi

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,97 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: 
+      - opened    # New PR
+      - edited    # PR title/description edited
+      - synchronize # New commits pushed
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+  statuses: write
+
+jobs:
+  check-pr-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Check PR Title Format
+        id: check-title
+        continue-on-error: true  # Allow the step to fail without failing the job
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          echo "Checking PR title: $PR_TITLE"
+          
+          # Check if title starts with valid type (including breaking change ! for any type)
+          if [[ ! "$PR_TITLE" =~ ^(feat!|fix!|docs!|style!|refactor!|perf!|test!|build!|ci!|chore!|revert!|feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert): ]]; then
+            echo "❌ PR title must start with one of these types, optionally followed by ! for breaking changes:"
+            echo "feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+            echo "Example: feat: new feature"
+            echo "Example: fix!: breaking bug fix"
+            echo "See the README for more details on commit message format."
+            exit 1
+          fi
+          
+          echo "✅ PR title format is valid"
+
+      - name: Verify Expected Behavior
+        run: |
+          # For invalid PR titles, we expect failure
+          if [[ "${{ github.event.pull_request.title }}" == "adding some feature without proper format" ]]; then
+            if [[ "${{ steps.check-title.outcome }}" == "failure" ]]; then
+              echo "✅ Test passed - Invalid PR title was rejected as expected"
+              exit 0
+            else
+              echo "❌ Test failed - Invalid PR title should have been rejected"
+              exit 1
+            fi
+          # For valid semantic PR titles, we expect success
+          else
+            if [[ "${{ steps.check-title.outcome }}" == "success" ]]; then
+              echo "✅ Test passed - Valid semantic PR title was accepted"
+              exit 0
+            else
+              echo "❌ Test failed - Valid semantic PR title should have been accepted"
+              exit 1
+            fi
+          fi
+
+      # - name: Wait for Vercel Preview
+      #   if: ${{ !env.ACT }}  # Only run in GitHub Actions, not in local act
+      #   env:
+      #     GH_TOKEN: ${{ github.token }}
+      #   run: |
+      #     echo "Waiting for Vercel deployment to complete..."
+      #     while true; do
+      #       # Debug output to see actual states
+      #       gh pr checks ${{ github.event.pull_request.number }} --json name,state,description | jq -r '.[] | select(.name=="Vercel")'
+      #       
+      #       STATUS=$(gh pr checks ${{ github.event.pull_request.number }} --json name,state,description | jq -r '.[] | select(.name=="Vercel") | .description')
+      #       if [[ "$STATUS" == *"Deployment has completed"* ]]; then
+      #         echo "✅ Vercel deployment completed successfully"
+      #         break
+      #       elif [[ "$STATUS" == *"failed"* ]]; then
+      #         echo "❌ Vercel deployment failed"
+      #         exit 1
+      #       fi
+      #       echo "⏳ Waiting for Vercel deployment... (checking again in 10s)"
+      #       sleep 10
+      #     done
+
+      - name: Check Breaking Change Format
+        if: success()
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          
+          # Check for breaking change indicator
+          if [[ "$PR_TITLE" =~ ^feat!: ]]; then
+            echo "⚠️ Breaking change detected in PR title"
+            echo "This will trigger a major version bump"
+          fi 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,185 @@
+name: Version Bump
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Default to cleanup containers on workflow completion
+env:
+  ACT_STOPPED_CONTAINER_RM: true  # Automatically remove stopped containers
+  ACT_FORCE_TERM: true             # Force terminate containers on SIGTERM
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    outputs:
+      pr_number: ${{ steps.get_pr.outputs.pr_number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Configure Git for GitHub Actions
+        if: ${{ github.actor != 'nektos/act' }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Install Dependencies
+        run: npm ci || npm install
+          
+      - name: Determine Version Bump Type
+        id: bump-type
+        run: |
+          PR_TITLE="${{ github.event.head_commit.message }}"
+          echo "PR Title: $PR_TITLE"
+          
+          if [[ "$PR_TITLE" =~ feat!: || "$PR_TITLE" =~ fix!: || "$PR_TITLE" =~ refactor!: ]]; then
+            echo "bump_type=major" >> $GITHUB_OUTPUT
+          elif [[ "$PR_TITLE" =~ feat: ]]; then
+            echo "bump_type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "bump_type=patch" >> $GITHUB_OUTPUT
+          fi
+          
+          echo "Determined bump type: $(cat $GITHUB_OUTPUT | grep bump_type | cut -d'=' -f2)"
+          
+      - name: Create Version Bump Branch
+        id: create-branch
+        run: |
+          BRANCH_NAME="version-bump-$(date +%s)"
+          echo "Creating branch: $BRANCH_NAME"
+          git checkout -b "$BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          
+          # Update version in package.json
+          npm version ${{ steps.bump-type.outputs.bump_type }} --no-git-tag-version
+          
+          # Stage and commit changes
+          git add package.json
+          git commit -m "chore: bump version [skip ci]"
+          git push origin "$BRANCH_NAME"
+          
+      - name: Create or Update Pull Request
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_TITLE="chore: version bump [skip ci]"
+          PR_BODY="Automated version bump triggered by merge to main branch"
+          
+          # Create labels if they don't exist (with --force to update)
+          gh label create automated --color "#0E8A16" --description "Automated changes" --force
+          gh label create version-bump --color "#1D76DB" --description "Version bump changes" --force
+          
+          # Debug output
+          echo "Creating PR from branch: ${{ steps.create-branch.outputs.branch_name }}"
+          
+          # Create PR and capture PR number using grep
+          PR_URL=$(gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --base main \
+            --head "${{ steps.create-branch.outputs.branch_name }}" \
+            --label "automated" \
+            --label "version-bump")
+            
+          # Extract PR number from URL
+          PR_NUMBER=$(echo "$PR_URL" | grep -o '[0-9]*$')
+          
+          echo "Created PR #$PR_NUMBER: $PR_URL"
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+      
+      - name: Get PR Number
+        id: get_pr
+        run: |
+          echo "pr_number=${{ steps.create-pr.outputs.pr_number }}" >> $GITHUB_OUTPUT
+
+  cleanup:
+    if: always()
+    needs: [version-bump, merge-pr]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean up containers
+        if: always()
+        run: |
+          # List and remove any running act containers
+          docker ps -a --filter "name=act-*" --format "{{.ID}}" | xargs -r docker rm -f || true
+          
+          # Remove any dangling containers
+          docker container prune -f
+          
+          # Remove any dangling images
+          docker image prune -f
+
+  merge-pr:
+    needs: version-bump
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Wait for checks and merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Waiting for checks to complete on PR #${{ needs.version-bump.outputs.pr_number }}"
+          
+          # Wait for checks to complete (timeout after 10 minutes)
+          timeout=600
+          while [ $timeout -gt 0 ]; do
+            # Get check status using correct fields
+            STATUSES=$(gh pr view ${{ needs.version-bump.outputs.pr_number }} --json statusCheckRollup --jq '.statusCheckRollup.[].state')
+            echo "Current check statuses:"
+            echo "$STATUSES"
+            
+            if echo "$STATUSES" | grep -q "PENDING"; then
+              echo "Checks still running... ($timeout seconds remaining)"
+              sleep 10
+              timeout=$((timeout - 10))
+              continue
+            fi
+            
+            if echo "$STATUSES" | grep -q "FAILURE"; then
+              echo "Some checks failed!"
+              exit 1
+            fi
+            
+            echo "All checks passed!"
+            
+            # Get the branch name before merging
+            BRANCH_NAME=$(gh pr view ${{ needs.version-bump.outputs.pr_number }} --json headRefName --jq '.headRefName')
+            
+            # Merge the PR
+            gh pr merge ${{ needs.version-bump.outputs.pr_number }} --merge --delete-branch
+            
+            # Double-check branch deletion and force delete if necessary
+            if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+              echo "Branch still exists, forcing deletion..."
+              git push origin --delete "$BRANCH_NAME" --force
+            fi
+            
+            echo "Successfully merged PR and cleaned up branch: $BRANCH_NAME"
+            exit 0
+          done
+          
+          echo "Timeout waiting for checks!"
+          exit 1

--- a/.windsurf/rules/README.md
+++ b/.windsurf/rules/README.md
@@ -1,0 +1,43 @@
+---
+trigger: always_on
+---
+
+# Windsurf Global Rules
+
+This directory contains global Windsurf rules that can be shared across all projects. These rules are designed to standardize workflows and practices across different repositories.
+
+## How Global Rules Work
+
+Global rules are applied across all workspaces and take precedence over workspace-specific rules. They are automatically loaded by Cascade when interacting with any repository.
+
+## Sharing Rules Across Projects
+
+To share these rules with other projects:
+
+1. Copy the `.windsurf/rules` directory to your other project repositories
+2. Alternatively, you can set up a central repository for these rules and symlink or copy them to other projects
+
+## Available Rules
+
+- **git_workflow_rules.md**: Standardized Git workflow practices including branch naming conventions and pull request creation processes
+
+## Best Practices
+
+- Keep rules concise and specific
+- Use bullet points, numbered lists, and markdown for clarity
+- Group related rules using XML tags (e.g., `<branch_creation>`, `<pull_request_workflow>`)
+- Limit each rule file to 6000 characters (Windsurf limitation)
+- Total global rules should not exceed 12,000 characters for optimal performance
+
+## Adding New Rules
+
+To add new global rules:
+
+1. Create a new markdown file in this directory with a descriptive name
+2. Format your rules using the best practices above
+3. Commit and push the changes to share with your team
+
+## Reference
+
+For more information on Windsurf Memories & Rules, visit:
+[https://docs.windsurf.com/windsurf/cascade/memories](https://docs.windsurf.com/windsurf/cascade/memories)

--- a/.windsurf/rules/documentation_standards.md
+++ b/.windsurf/rules/documentation_standards.md
@@ -1,0 +1,44 @@
+---
+trigger: always_on
+---
+
+# Documentation Standards
+
+## README Maintenance
+
+### Package.json Scripts
+
+- When adding or modifying scripts in `package.json`:
+  1. Update the README's "Available Scripts" section to reflect the changes
+  2. Document the purpose of each script
+  3. Group related scripts under appropriate headings (e.g., "Docker Management", "Testing")
+  4. Include any important notes or warnings for potentially destructive commands
+
+### Prerequisites
+
+- List all required software and tools in the Prerequisites section
+- Include version requirements where applicable
+- Provide installation links for all dependencies
+
+### Quick Start Guide
+
+- Keep the quick start guide up-to-date with the current setup process
+- Include all necessary steps to get started
+- Use code blocks with proper syntax highlighting
+- Add any environment variables or configuration needed
+
+## Workflow Documentation
+
+- Each workflow in the `workflows/examples/` directory should include:
+  - A `README.md` explaining the workflow's purpose
+  - Required setup steps
+  - Example inputs/outputs
+  - Any dependencies or prerequisites
+
+## Style Guidelines
+
+- Use consistent heading levels
+- Include blank lines around headings and lists
+- Use backticks for file names, directory names, and commands
+- Include descriptive alt text for images
+- Keep line lengths under 100 characters where possible

--- a/.windsurf/rules/git_workflow_rules.md
+++ b/.windsurf/rules/git_workflow_rules.md
@@ -1,0 +1,73 @@
+---
+trigger: always_on
+---
+
+# Git Workflow Rules
+
+These global rules define standardized Git workflow practices to be applied across all projects.
+
+<branch_creation>
+
+- Always prefix new branch names with today's date in the format YYYY.MM.DD/ (e.g., 2025.05.08/)
+- When creating new branches, always use the equivalent of 'gcob' alias: 'git checkout -b BRANCH-NAME && git push --set-upstream origin BRANCH-NAME'
+- This ensures new branches are created locally and immediately pushed to the remote with upstream tracking set
+- Never use plain 'git checkout -b' or track main by default
+
+</branch_creation>
+
+<pull_request_workflow>
+
+- When asked to create a pull request for a branch, follow this process:
+  1. Review the work and commits completed in the branch
+  2. Review GitHub Workflows to check for any PR title naming conventions
+  3. Use the contents of .github/pull_request_template.md as the template for the PR body
+  4. Use the GitHub CLI (gh) to create the pull request with a properly formatted body:
+
+     ```bash
+     gh pr create --title "TITLE" --body "# Description
+
+<!-- Describe your changes here -->
+
+## Type of Change
+
+<!-- Add one of these version tags: -->
+version: feat     # New feature (minor version bump)
+version: feat!    # Breaking change (major version bump)
+version: fix      # Bug fix (patch version bump)
+version: docs     # Documentation changes
+version: style    # Code style/formatting
+version: refactor # Code refactoring
+version: perf     # Performance improvements
+version: test     # Adding/updating tests
+version: build    # Dependencies/build changes
+version: ci       # CI/CD changes
+version: chore    # General maintenance
+version: revert   # Reverting changes
+
+## Testing
+
+- [ ] I have tested these changes locally using `act`
+- [ ] All existing tests pass
+- [ ] My commits are signed with GPG"
+
+- **PR Description Guidelines**:
+  - Use proper markdown formatting with clear section headers
+  - Escape special characters in shell commands
+  - Use code blocks with language specification (e.g., \`\`\`bash, \`\`\`javascript)
+  - Keep the description concise but informative
+  - Note any breaking changes or important considerations
+
+- **Code Formatting Rules**:
+  - Never automatically commit code changes without explicit approval
+  - Verify all changes work as expected before suggesting commits
+  - Provide clear explanations of changes before implementing them
+  - Use proper escaping for multiline strings in shell commands
+  - Always verify the output format before submitting
+
+- If a PR has already been created but needs modification:
+  1. NEVER close and recreate a PR - this loses PR history and creates confusion
+  2. Always use `gh pr edit PR-NUMBER` to modify an existing PR
+  3. For body changes: `gh pr edit PR-NUMBER --body "NEW-BODY"`
+  4. For title changes: `gh pr edit PR-NUMBER --title "NEW-TITLE"`
+
+</pull_request_workflow>

--- a/.windsurf/rules/project_specific_rules.md
+++ b/.windsurf/rules/project_specific_rules.md
@@ -1,0 +1,21 @@
+---
+trigger: always_on
+---
+
+# Project Rules
+
+## Semantic Versioning
+
+- Follow semantic versioning for all changes
+- Use appropriate prefixes in PR titles and commit messages:
+  - `feat:` for new features (minor version bump)
+  - `feat!:` for breaking changes (major version bump)
+  - `fix:` for bug fixes (patch version bump)
+  - Other valid prefixes: `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `build:`, `ci:`, `chore:`, `revert:`
+- Ensure PR titles match the semantic versioning pattern required by CI checks
+
+## Project-Specific Guidelines
+
+- Add your project-specific rules and guidelines here
+- Document coding standards specific to this project
+- Include any architectural decisions or patterns to follow

--- a/.windsurf/rules/project_template_rules.md
+++ b/.windsurf/rules/project_template_rules.md
@@ -1,0 +1,47 @@
+---
+trigger: always_on
+---
+
+# Project Template Rules
+
+These rules provide a template for project-specific configurations that can be customized for each repository.
+
+## Project Structure
+
+- Follow the established project structure for the repository
+- Place documentation in the appropriate directories (e.g., `/docs`)
+- Maintain consistent file naming conventions within the project
+
+## Code Style
+
+- Follow the language-specific style guides for the project
+- Use consistent indentation and formatting
+- Add appropriate comments and documentation
+- Follow naming conventions for variables, functions, and classes
+
+## Commit Messages
+
+- Write clear, concise commit messages
+- Begin commit messages with a type prefix (e.g., feat:, fix:, docs:)
+- Reference issue numbers when applicable
+- Separate subject from body with a blank line
+- Use imperative mood in the subject line
+
+## Testing
+
+- Write tests for new features and bug fixes
+- Ensure all tests pass before submitting a pull request
+- Maintain test coverage at or above the project's standard
+
+## Documentation
+
+- Update documentation when making changes to code
+- Document APIs, functions, and complex logic
+- Keep README files up-to-date with current project information
+- Include examples where appropriate
+
+## Deployment
+
+- Follow the project's deployment process
+- Test changes in development/staging environments before production
+- Document any deployment-specific considerations

--- a/README.md
+++ b/README.md
@@ -1,8 +1,38 @@
-# Welcome
+# Yahoo! Pigskin Pick'em
 
 This project has been created to track and explore fantasy football data in our fun Yahoo! Pigskin Pick'em league.
 
-Additional resources
+## 🚀 Features
+
+- Season-by-season tracking of picks and standings
+- Weekly pick analysis and results
+- Historical data for multiple seasons
+
+## 🛠️ Prerequisites
+
+- Node.js
+- npm
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (for local workflow testing)
+- [act CLI tool](https://github.com/nektos/act) (for local GitHub Actions testing)
+
+## 🧪 Testing Workflows
+
+This project includes GitHub Actions workflows that can be tested locally using the [act CLI tool](https://github.com/nektos/act).
+
+### Available Test Commands
+
+- `npm test` - Run all tests and GitHub workflows
+- `npm run test:workflows` - Only test GitHub workflows
+
+## 🤖 GitHub Actions
+
+This repository includes the following GitHub Actions workflows:
+
+- **PR Title Check**: Validates PR titles against conventional commit messages
+- **Version Bump**: Handles version bumping and changelog generation on merge to main
+- **GHCR Cleanup**: Automatically cleans up old GitHub Container Registry images
+
+## Additional Resources
 
 - [Tiebreakers for Pick'em games](https://help.yahoo.com/kb/SLN6629.html#:~:text=For%20any%20week%20where%202,for%20the%20first%20Tiebreak%20Game.)
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "yahoo-pigskin-pickem",
   "version": "0.0.0",
   "description": "A fun project to track and explore Yahoo! Pigskin Pick'em data with my friends and loved ones.",
-  "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run test:workflows",
+    "test:workflows": "chmod +x .github/test-workflows.sh && .github/test-workflows.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

This PR adds GitHub workflows and tests from the starting-point repository to the Pigskin Pick'em repo. The changes include:

- Added GitHub workflow folder and contents (pr-title-check.yml, version-bump.yml, ghcr-cleanup.yml)
- Added Windsurf rules folder and contents
- Updated package.json to include test scripts for running GitHub workflow tests
- Removed the "main" entry from package.json
- Updated the main README.md with test information

## Type of Change

version: feat     # New feature (minor version bump)

## Testing

- [x] I have tested these changes locally using `act`
- [x] All existing tests pass
- [x] My commits are signed with GPG