### PR TITLE
fix: disable JSON schema downloading in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "peasy",
     "pickem",
     "pullmytail"
-  ]
+  ],
+  "json.schemaDownload.enable": false
 }


### PR DESCRIPTION
# Description

This PR fixes the issue with VS Code showing errors related to schema loading:
"Problems loading reference 'vscode://schemas/mcp': Unable to load schema from 'vscode://schemas/mcp': Error (FileSystemError): Unable to read file 'vscode://schemas/mcp' (EntryNotFound)."

The fix adds the  setting set to  in the VS Code settings file to disable automatic schema downloading.

## Type of Change

version: fix      # Bug fix (patch version bump)

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] My commits are signed with GPG